### PR TITLE
Lock berkshelf gem to 1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "berkshelf"
+gem "berkshelf", "~> 1.2.1"


### PR DESCRIPTION
berkshelf 1.3+ removed berkshelf/vagrant from core and seems to require
Vagrant 1.1, which is now incompatible with this repo (see README)

You can see berkshelf/vagrant removal here: https://github.com/RiotGames/berkshelf/commit/a3953a6e4a50b02c598f999128f18b1fb346efeb ; maybe there's a better way to fix this, I don't know exactly what are the incompatibilities with Vagrant 1.1+...

Anyway thanks for a great way to test riak_cs ! ;-)
