### PR TITLE
Reduce number of steps required to get Riak CS running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ Gemfile.lock
 \#*#
 .*.sw[a-z]
 *.un~
-/cookbooks
 /bin

--- a/Berksfile
+++ b/Berksfile
@@ -8,5 +8,6 @@ cookbook "htop"
 cookbook "openssh"
 cookbook "sudo"
 
-cookbook "riak_cs", github: "basho/riak-cs-chef-cookbook", protocol: :ssh
-cookbook "riak", github: "hectcastro/riak-chef-cookbook", protocol: :ssh, branch: "riak_cs_kv_multi_backend"
+cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook"
+cookbook "riak", github: "basho/riak-chef-cookbook"
+cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem "berkshelf"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vagrant Riak CS Cluster
 
 This is a Vagrant project powered by Chef to bring up a local Riak CS cluster.
-Each node can run either `Ubuntu 12.04` or `CentOS 6.3` 32-bit with `1024MB`
+Each node can run either `Ubuntu 12.04` or `CentOS 6.3` 32-bit with `1536MB`
 of RAM by default. If you want to tune the OS or node/memory count, you'll
 have to edit the `Vagrantfile` directly.
 
@@ -15,12 +15,11 @@ Download and install Vagrant via the
 **Note**: It is necessary, at present, to install Vagrant 1.0.7 due to a
 compatibility issue.
 
-### Install cookbooks
+### Clone repository
 
 ``` bash
-$ gem install bundler
-$ bundle install
-$ bundle exec berks install
+$ git clone https://github.com/hectcastro/vagrant-riak-cs-cluster.git
+$ cd vagrant-riak-cs-cluster
 ```
 
 ### Launch cluster
@@ -29,22 +28,23 @@ $ bundle exec berks install
 $ RIAK_CS_CREATE_ADMIN_USER=1 vagrant up
 ```
 
-### Create admin user
+### Test cluster
 
 ``` bash
-$ curl -H 'Content-Type: application/json'                  \
-       -X POST http://localhost:8080/riak-cs/user           \
-       --data '{"email":"admin@admin.com", "name":"admin"}'
-$ RIAK_CS_ADMIN_KEY="<ADMIN_KEY>" RIAK_CS_SECRET_KEY="<SECRET_KEY>" vagrant provision
+$ s3cmd -c ~/.s3cfgfasttrack --configure
 ```
 
-## Accessing individual nodes
+There are 4 default settings you should change:
 
-Each node in the cluster is named in the form `riakN` — where `N` is a number
-between `1` and the number of nodes defined for the cluster.
+* **Access Key** - Replace with value next to `Riak CS Key` in the Chef
+  provisioning output.
+* **Secret Key** - Replace with value next to `Riak CS Secret` in the Chef
+  provisioning output.
+* **Proxy Server**: `localhost`
+* **Proxy Port**: `8080`
 
 ``` bash
-$ vagrant ssh riak1
+$ s3cmd -c ~/.s3cfgfasttrack mb s3://test-bucket
 ```
 
 ## Vagrant boxes

--- a/cookbooks/.gitignore
+++ b/cookbooks/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/roles/riak.rb
+++ b/roles/riak.rb
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "erlang_template_helper"
 
-name "riak_cs"
+name "riak"
 description "Role for Riak Enterprise nodes."
 run_list(
   "recipe[riak]"

--- a/roles/riak_cs.rb
+++ b/roles/riak_cs.rb
@@ -6,14 +6,5 @@ require "erlang_template_helper"
 name "riak_cs"
 description "Role for Riak CS nodes."
 run_list(
-  "recipe[riak_cs]"
-)
-default_attributes(
-  "riak_cs" => {
-    "config" => {
-      "riak_cs" => {
-        "cs_root_host" => "riakcs.dev".to_erl_string
-      }
-    }
-  }
+  "recipe[riak-cs]"
 )

--- a/roles/stanchion.rb
+++ b/roles/stanchion.rb
@@ -6,5 +6,5 @@ require "erlang_template_helper"
 name "stanchion"
 description "Role for the Stanchion node."
 run_list(
-  "recipe[riak_cs::stanchion]"
+  "recipe[riak-cs::stanchion]"
 )


### PR DESCRIPTION
This project now includes the `riak-cs-create-admin-user` cookbook that automates the creation of an administrative user and reconfiguration of Stanchion and Riak CS.

The corresponding documentation update PR is here: https://github.com/basho/basho_docs/pull/276

/cc @tylerhannan 
