### PR TITLE
Updated the Opscode base boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Vagrant project powered by Chef to bring up a local [Riak
 CS](https://github.com/basho/riak_cs) cluster. Each node can run either `Ubuntu
-12.04` or `CentOS 6.3` 64-bit with `1536MB` of RAM by default. If you want to
+12.04` or `CentOS 6.4` 64-bit with `1536MB` of RAM by default. If you want to
 tune the OS or node/memory count, you'll have to edit the `Vagrantfile`
 directly.
 
@@ -59,7 +59,7 @@ The Vagrant boxes used in this project were created by
 [Veewee](https://github.com/jedi4ever/veewee/). To view the Veewee definitions,
 please follow the links below:
 
-* [opscode-centos-6.3](https://github.com/opscode/bento/tree/master/definitions/centos-6.3)
+* [opscode-centos-6.4](https://github.com/opscode/bento/tree/master/definitions/centos-6.4)
 * [opscode-ubuntu-12.04](https://github.com/opscode/bento/tree/master/definitions/ubuntu-12.04)
 
 ## Erlang template helper

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,13 +3,13 @@
 
 CENTOS = {
   sudo_group: "wheel",
-  box: "opscode-centos-6.3",
-  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box"
+  box: "opscode-centos-6.4",
+  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_chef-11.4.4.box"
 }
 UBUNTU = {
   sudo_group: "sudo",
   box: "opscode-ubuntu-12.04",
-  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.2.0.box"
+  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.4.4.box"
 }
 
 NODES         = 1


### PR DESCRIPTION
Updated the default Vagrant base boxes. Chef on both boxes has been updated to `11.4.4`. The CentOS box has been updated to `6.4`.
