### PR TITLE
Bumped version of riak-cs-create-admin-user cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -10,4 +10,4 @@ cookbook "sudo"
 
 cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.0.0"
 cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.0.0"
-cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.2.0"
+cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.0"


### PR DESCRIPTION
This version of the `riak-cs-create-admin-user` cookbook adds support for reusing generated Riak CS access and secret keys.

See: https://github.com/hectcastro/chef-riak-cs-create-admin-user/pull/3
