### PR TITLE
Fixing Berkshelf Problem

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |cluster|
           sudo apt-get install -qq -y git libxslt1-dev
         else
           sudo yum update
-          sudo yum install -q -y git libxslt1-dev
+          sudo yum install -q -y git libxslt-devel
         fi
         if [ ! -x /opt/chef/embedded/bin/berks ]; then
           echo "Installing berkshelf"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,9 +44,11 @@ Vagrant.configure("2") do |cluster|
       config.vm.provision :shell, :inline => <<-SCRIPT.gsub(/^ {8}/, '')
         #!/bin/sh
         if [ -x /usr/bin/apt-get ]; then
-          sudo apt-get install -qq -y git
+          sudo apt-get update
+          sudo apt-get install -qq -y git libxslt1-dev
         else
-          sudo yum install -q -y git
+          sudo yum update
+          sudo yum install -q -y git libxslt1-dev
         fi
         if [ ! -x /opt/chef/embedded/bin/berks ]; then
           echo "Installing berkshelf"


### PR DESCRIPTION
This change fixes the following error which started happening with new versions of vagrant and virtual box:

```
ERROR:  Error installing berkshelf:
    ERROR: Failed to build gem native extension.

        /opt/chef/embedded/bin/ruby extconf.rb
checking for libxml/parser.h... no
-----
libxml2 is missing.  please visit http://nokogiri.org/tutorials/installing_nokogiri.html for help with installing dependencies.
-----
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of
necessary libraries and/or headers.  Check the mkmf.log file for more
details.  You may need configuration options.

Provided configuration options:
    --with-opt-dir
    --with-opt-include
    --without-opt-include=${opt-dir}/include
    --with-opt-lib
    --without-opt-lib=${opt-dir}/lib
    --with-make-prog
    --without-make-prog
    --srcdir=.
    --curdir
    --ruby=/opt/chef/embedded/bin/ruby
    --with-zlib-dir
    --without-zlib-dir
    --with-zlib-include
    --without-zlib-include=${zlib-dir}/include
    --with-zlib-lib
    --without-zlib-lib=${zlib-dir}/lib
    --with-iconv-dir
    --without-iconv-dir
    --with-iconv-include
    --without-iconv-include=${iconv-dir}/include
    --with-iconv-lib
    --without-iconv-lib=${iconv-dir}/lib
    --with-xml2-dir
    --without-xml2-dir
    --with-xml2-include
    --without-xml2-include=${xml2-dir}/include
    --with-xml2-lib
    --without-xml2-lib=${xml2-dir}/lib
    --with-xslt-dir
    --without-xslt-dir
    --with-xslt-include
    --without-xslt-include=${xslt-dir}/include
    --with-xslt-lib
    --without-xslt-lib=${xslt-dir}/lib
    --with-libxslt-config
    --without-libxslt-config
    --with-pkg-config
    --without-pkg-config
    --with-libxml-2.0-config
    --without-libxml-2.0-config
    --with-pkg-config
    --without-pkg-config
    --with-libiconv-config
    --without-libiconv-config
    --with-pkg-config
    --without-pkg-config


Gem files will remain installed in /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/nokogiri-1.5.9 for inspection.
Results logged to /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/nokogiri-1.5.9/ext/nokogiri/gem_make.out
Berkshelf: Installing cookbooks
sudo
: 
/opt/chef/embedded/bin/berks: command not found

mv: 
cannot stat `/tmp/vagrant-chef-1/chef-solo-1/cookbooks//*'
: No such file or directory

The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

chmod +x /tmp/vagrant-shell && /tmp/vagrant-shell

```
