### PR TITLE
Riak CS performance and capacity settings

### DIFF
--- a/roles/riak.rb
+++ b/roles/riak.rb
@@ -10,6 +10,12 @@ run_list(
 )
 default_attributes(
   "riak" => {
+    "args" => {
+      "+zdbbl" => 96000,
+      "-env" => {
+        "ERL_MAX_PORTS" => 16384
+      }
+    },
     "config" => {
       "riak_core" => {
         "default_bucket_props" => [["allow_mult", true].to_erl_tuple]


### PR DESCRIPTION
Upped `+zdbbl` to `96000` and `ERL_MAX_PORTS` to `16384` in the `vm.args` for Riak according to the Performance and Capacity section here [0].

[0] http://docs.basho.com/riakcs/latest/cookbooks/configuration/Configuring-Riak/
