### PR TITLE
Forwards the Riak HTTP port to locahost:8098

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,8 @@ Vagrant.configure("2") do |cluster|
         config.vm.network :forwarded_port, guest: 8080, host: 8080
         config.vm.network :forwarded_port, guest: 8085, host: 8085
         config.vm.network :forwarded_port, guest: 8087, host: 8087
-      end
+        config.vm.network :forwarded_port, guest: 8098, host: 8098
+       end
 
       config.vm.hostname = "riak#{index}"
       config.vm.network :private_network, ip: "#{BASE_IP}.#{last_octet}"

--- a/cookbooks/.gitignore
+++ b/cookbooks/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/cookbooks/.gitignore
+++ b/cookbooks/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Forwards the underlying Riak HTTP port to support development/evaluation scenarios where users want to use the underlying Riak KV instance.

**N.B.** The underlying Riak cluster should **not** be directly accessed in production Riak CS clusters for performance and security reasons.

CC @hectcastro 
