### PR TITLE
Remove internal Berkshelf workflow and other things...

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -9,4 +9,4 @@ cookbook "openssh"
 
 cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.0.0"
 cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.1.0"
-cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.0"
+cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"

--- a/Berksfile
+++ b/Berksfile
@@ -8,5 +8,5 @@ cookbook "htop"
 cookbook "openssh"
 
 cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.0.0"
-cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.0.0"
+cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.1.0"
 cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.0"

--- a/Berksfile
+++ b/Berksfile
@@ -6,7 +6,6 @@ cookbook "ntp"
 cookbook "nmap"
 cookbook "htop"
 cookbook "openssh"
-cookbook "sudo"
 
 cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.0.0"
 cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.0.0"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ directly.
 Download and install Vagrant via the
 [Vagrant installer](http://downloads.vagrantup.com/).
 
+### Install Vagrant plugins
+
+``` bash
+$ vagrant plugin install vagrant-berkshelf
+$ vagrant plugin install vagrant-omnibus
+```
+
 ### Clone repository
 
 ``` bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,12 +33,10 @@ Vagrant.configure("2") do |cluster|
 
       # Setup the network and additional file shares.
       if index == 1
-        config.vm.network :forwarded_port, guest: 8000, host: 8000
-        config.vm.network :forwarded_port, guest: 8080, host: 8080
-        config.vm.network :forwarded_port, guest: 8085, host: 8085
-        config.vm.network :forwarded_port, guest: 8087, host: 8087
-        config.vm.network :forwarded_port, guest: 8098, host: 8098
-       end
+        [ 8000, 8080, 8085, 8087, 8098 ].each do |port|
+          config.vm.network :forwarded_port, guest: port, host: port
+        end
+      end
 
       config.vm.hostname = "riak#{index}"
       config.vm.network :private_network, ip: "#{BASE_IP}.#{last_octet}"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,12 @@ BASE_IP       = "33.33.33"
 IP_INCREMENT  = 10
 
 Vagrant.configure("2") do |cluster|
+  # Ensure latest version of Chef is installed.
+  cluster.omnibus.chef_version = :latest
+
+  # Utilize the Berkshelf plugin to resolve cookbook dependencies.
+  cluster.berkshelf.enabled = true
+
   (1..NODES).each do |index|
     last_octet = index * IP_INCREMENT
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,12 +2,10 @@
 # vi: set ft=ruby :
 
 CENTOS = {
-  sudo_group: "wheel",
   box: "opscode-centos-6.4",
   url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_chef-11.4.4.box"
 }
 UBUNTU = {
-  sudo_group: "sudo",
   box: "opscode-ubuntu-12.04",
   url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.4.4.box"
 }
@@ -62,11 +60,6 @@ Vagrant.configure("2") do |cluster|
         end
 
         chef.json = {
-          "authorization" => {
-            "sudo" => {
-              "groups" => [ OS[:sudo_group] ],
-            }
-          },
           "riak" => {
             "args" => {
               "+S" => 1,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,29 +40,9 @@ Vagrant.configure("2") do |cluster|
       config.vm.network :private_network, ip: "#{BASE_IP}.#{last_octet}"
       config.vm.synced_folder "lib/", "/tmp/vagrant-chef-1/lib"
 
-      # Hack for Berkshelf until the following bug is resolved:
-      # https://github.com/RiotGames/berkshelf-vagrant/issues/4
-      config.vm.provision :shell, :inline => <<-SCRIPT.gsub(/^ {8}/, '')
-        #!/bin/sh
-        if [ -x /usr/bin/apt-get ]; then
-          sudo apt-get update
-          sudo apt-get install -qq -y git libxslt-dev libxml2-dev
-        else
-          sudo yum install -q -y git libxslt-devel libxml2-devel
-        fi
-        if [ ! -x /opt/chef/embedded/bin/berks ]; then
-          echo "Installing berkshelf"
-          sudo /opt/chef/embedded/bin/gem install berkshelf --no-ri --no-rdoc --quiet --version '= 1.4.3'
-        fi
-        echo "Berkshelf: Installing cookbooks"
-        sudo /opt/chef/embedded/bin/berks install -b /vagrant/Berksfile -p /tmp/vagrant-chef-1/chef-solo-1/cookbooks
-        sudo mv /tmp/vagrant-chef-1/chef-solo-1/cookbooks/`ls -1 /tmp/vagrant-chef-1/chef-solo-1/cookbooks/`/* /tmp/vagrant-chef-1/chef-solo-1/cookbooks
-      SCRIPT
-
       # Provision using Chef.
       config.vm.provision :chef_solo do |chef|
         chef.roles_path = "roles"
-        chef.cookbooks_path = "cookbooks"
 
         if config.vm.box =~ /ubuntu/
           chef.add_recipe "apt"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,11 @@
 
 CENTOS = {
   box: "opscode-centos-6.4",
-  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_chef-11.4.4.box"
+  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box"
 }
 UBUNTU = {
   box: "opscode-ubuntu-12.04",
-  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.4.4.box"
+  url: "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
 }
 
 NODES         = 1

--- a/cookbooks/.gitignore
+++ b/cookbooks/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/roles/base.rb
+++ b/roles/base.rb
@@ -4,15 +4,9 @@ run_list(
   "recipe[ntp]",
   "recipe[nmap]",
   "recipe[htop]",
-  "recipe[openssh]",
-  "recipe[sudo]"
+  "recipe[openssh]"
 )
 default_attributes(
-  "authorization" => {
-    "sudo" => {
-      "passwordless" => true
-    }
-  },
   "openssh" => {
     "server" => {
       "password_authentication" => "no"


### PR DESCRIPTION
This pull request contains several changes that attempt to ease the maintainability of this project:
- Replace internal Berkshelf workflow with the [vagrant-berkshelf](https://github.com/riotgames/vagrant-berkshelf) plugin
- Update Vagrant boxes with their provisionerless replacements and take care of provisioner installation (Chef) via [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus)
- Remove `sudo` cookbook dependency because Vagrant boxes already require the `vagrant` user to have `sudo` capabilities
- Bump Riak cookbook version to `v2.1.0`
