### PR TITLE
Ensure riak_cs_kv_multi_backend is installed before starting Riak

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,6 @@ cookbook "nmap"
 cookbook "htop"
 cookbook "openssh"
 
-cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.1.0"
-cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.0"
+cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.2.0"
+cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.1"
 cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"

--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,6 @@ cookbook "nmap"
 cookbook "htop"
 cookbook "openssh"
 
-cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.2.0"
+cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.2.1"
 cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.1"
 cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"

--- a/Berksfile
+++ b/Berksfile
@@ -8,5 +8,5 @@ cookbook "htop"
 cookbook "openssh"
 
 cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", ref: "2.2.1"
-cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.1"
+cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.2"
 cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"

--- a/README.md
+++ b/README.md
@@ -27,20 +27,6 @@ $ git clone https://github.com/basho/vagrant-riak-cs-cluster.git
 $ cd vagrant-riak-cs-cluster
 ```
 
-### Customize the cluster
-
-By default, the cluster will be built using the following options:
-
-  * nodes: 1
-  * base_ip: 33.33.33
-  * ip_increment: 10
-  * cores: 1
-  * memory: 1536 (bytes)
-  * riak_listen_address: 10.0.2.15
-  * riak_cs_listen_address: 10.0.2.15
-
-These defaults can be overridden by creating a `vagrant-overrides.conf` file in the same directory as the Vagrantfile in the form of `key=value` (e.g. cores=2).
-
 ### Launch cluster
 
 ``` bash
@@ -65,6 +51,23 @@ There are 4 default settings you should change:
 ``` bash
 $ s3cmd -c ~/.s3cfgfasttrack mb s3://test-bucket
 ```
+
+### Customize cluster
+
+By default, the cluster will be built using the following options:
+
+```
+nodes=1
+base_ip=33.33.33
+ip_increment=10
+cores=1
+memory=1536
+riak_listen_address=10.0.2.15
+riak_cs_listen_address=10.0.2.15
+```
+
+These defaults can be overridden by creating a `vagrant-overrides.conf` file
+in the same directory as the Vagrantfile in the form of `key=value`.
 
 ## Riak CS Control
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,8 +65,8 @@ Vagrant.configure("2") do |cluster|
         end
 
         chef.add_role "base"
-        chef.add_role "riak_cs"
         chef.add_role "riak"
+        chef.add_role "riak_cs"
         chef.add_role "stanchion" if index == 1
 
         if !ENV["RIAK_CS_CREATE_ADMIN_USER"].nil? && index == 1
@@ -116,8 +116,6 @@ Vagrant.configure("2") do |cluster|
           }
         }
       end
-
-      config.vm.provision :shell, :inline => "sudo service riak-cs start"
     end
   end
 end

--- a/roles/riak.rb
+++ b/roles/riak.rb
@@ -1,6 +1,7 @@
 name "riak"
 description "Role for Riak Enterprise nodes."
 run_list(
+  "recipe[riak-cs::package]",
   "recipe[riak]"
 )
 default_attributes(


### PR DESCRIPTION
At one point Riak init scripts would fail silently on start if there was a configuration error. Since that issue was resolved in our packages, a [hack](https://github.com/basho/vagrant-riak-cs-cluster/commit/9debb64c92b6ba2e21f287987bd1320482bb4e9e) was introduced so that this project could work around it.

This PR resolves the issue a little better by leveraging a [modularized](https://github.com/basho/riak-cs-chef-cookbook/pull/21) Riak CS cookbook.

**Note**: Please do not merge until the following are merged:
- https://github.com/basho/riak-chef-cookbook/pull/84
- https://github.com/basho/riak-cs-chef-cookbook/pull/21
- https://github.com/basho/riak-cs-chef-cookbook/pull/22
