### PR TITLE
Add additional overrides for Riak, Riak CS, and Stanchion configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ base_ip=33.33.33
 ip_increment=10
 cores=1
 memory=1536
-riak_listen_address=10.0.2.15
-riak_cs_listen_address=10.0.2.15
+riak_listen_address=127.0.0.1
+stanchion_listen_address=33.33.33.10
+riak_cs_root_host=s3.amazonaws.com
+riak_cs_listen_address=0.0.0.0
+riak_cs_rewrite_module=riak_cs_s3_rewrite
+riak_cs_auth_module=>riak_cs_s3_auth
 ```
 
 These defaults can be overridden by creating a `vagrant-overrides.conf` file

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,12 @@ options = {
   :ip_increment => 10,
   :cores => 1,
   :memory => 1536,
-  :riak_listen_address => "10.0.2.15",
-  :riak_cs_listen_address => "10.0.2.15"
+  :riak_listen_address => "127.0.0.1",
+  :stanchion_listen_address => "33.33.33.10",
+  :riak_cs_root_host => "s3.amazonaws.com",
+  :riak_cs_listen_address => "0.0.0.0",
+  :riak_cs_rewrite_module => "riak_cs_s3_rewrite",
+  :riak_cs_auth_module => "riak_cs_s3_auth"
 }
 
 CONF_FILE = Pathname.new("vagrant-overrides.conf")
@@ -82,7 +86,8 @@ Vagrant.configure("2") do |cluster|
             },
             "config" => {
               "riak_api" => {
-                "pb_ip" => "__string_#{options[:riak_listen_address]}"
+                "pb" =>
+                  { "__string_#{options[:riak_listen_address]}" => 8087 }
               },
               "riak_core" => {
                 "http" =>
@@ -97,8 +102,13 @@ Vagrant.configure("2") do |cluster|
             },
             "config" => {
               "riak_cs" => {
+                "riak_ip" => "__string_#{options[:riak_listen_address]}",
+                "stanchion_ip" => "__string_#{options[:stanchion_listen_address]}",
                 "anonymous_user_creation" => ((ENV["RIAK_CS_CREATE_ADMIN_USER"].nil? || index != 1) ? false : true),
-                "cs_ip" => "__string_#{options[:riak_cs_listen_address]}"
+                "cs_root_host" => "__string_#{options[:riak_cs_root_host]}",
+                "cs_ip" => "__string_#{options[:riak_cs_listen_address]}",
+                "rewrite_module" => options[:riak_cs_rewrite_module],
+                "auth_module" => options[:riak_cs_auth_module]
               }
             }
           },
@@ -106,6 +116,12 @@ Vagrant.configure("2") do |cluster|
             "args" => {
               "+S" => 1,
               "-name" => "stanchion@#{options[:base_ip]}.#{last_octet}"
+            },
+            "config" => {
+              "stanchion" => {
+                "riak_ip" => "__string_#{options[:riak_listen_address]}",
+                "stanchion_ip" => "__string_#{options[:stanchion_listen_address]}"
+              }
             }
           },
           "riak_cs_control" => {


### PR DESCRIPTION
Added the following overrides:
- `stanchion_listen_address`
- `riak_cs_root_host`
- `riak_cs_rewrite_module`
- `riak_cs_auth_module`

/cc @jburwell
