### PR TITLE
Add optional support for vagrant-cachier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Download and install Vagrant via the
 ``` bash
 $ vagrant plugin install vagrant-berkshelf
 $ vagrant plugin install vagrant-omnibus
+$ vagrant plugin install vagrant-cachier (Use RIAK_CS_USE_CACHE to enable)
 ```
 
 ### Clone repository
@@ -30,7 +31,7 @@ $ cd vagrant-riak-cs-cluster
 ### Launch cluster
 
 ``` bash
-$ RIAK_CS_CREATE_ADMIN_USER=1 vagrant up
+$ RIAK_CS_USE_CACHE=1 RIAK_CS_CREATE_ADMIN_USER=1 vagrant up
 ```
 
 ### Test cluster

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,11 @@ Vagrant.configure("2") do |cluster|
   # Ensure latest version of Chef is installed.
   cluster.omnibus.chef_version = :latest
 
+  # Utilize the Cachier plugin to cache downloaded packages.
+  unless ENV["RIAK_CS_USE_CACHE"].nil?
+    cluster.cache.auto_detect = true
+  end
+
   # Utilize the Berkshelf plugin to resolve cookbook dependencies.
   cluster.berkshelf.enabled = true
 


### PR DESCRIPTION
If the `RIAK_CS_USE_CACHE` flag is set, the [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) plugin is used to cache Chef, APT, and YUM packages.
