### PR TITLE
Bump Riak and Riak CS cookbooks (default to Riak CS 1.4.3)

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,6 @@ cookbook "nmap"
 cookbook "htop"
 cookbook "openssh"
 
-cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.4"
-cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", tag: "2.2.3"
+cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.4.1"
+cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", tag: "2.2.4"
 cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"

--- a/roles/riak.rb
+++ b/roles/riak.rb
@@ -13,6 +13,9 @@ default_attributes(
       }
     },
     "config" => {
+      "riak_api" => {
+        "pb_backlog" => 128
+      },
       "riak_core" => {
         "default_bucket_props" => [["__tuple", "allow_mult", true]]
       },

--- a/roles/riak_cs.rb
+++ b/roles/riak_cs.rb
@@ -3,3 +3,12 @@ description "Role for Riak CS nodes."
 run_list(
   "recipe[riak-cs]"
 )
+default_attributes(
+  "riak_cs" => {
+    "config" => {
+      "riak_cs" => {
+        "fold_objects_for_list_keys" => true
+      }
+    }
+  }
+)


### PR DESCRIPTION
In addition to bumping the cookbook version:
- [x] Set Riak's `pb_backlog` to the same as `request_pool` for Riak CS (resolves #31)
- [x] Set `fold_objects_for_list_keys` to `true` (requires Riak 1.4+)
