### PR TITLE
Update default version of Riak to 1.4.7

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,12 +1,10 @@
 site :opscode
 
-cookbook "apt"
-cookbook "yum"
 cookbook "ntp"
 cookbook "nmap"
 cookbook "htop"
 cookbook "openssh"
 
-cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.4.1"
-cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", tag: "2.2.4"
+cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.4.4"
+cookbook "riak-cs", github: "basho/riak-cs-chef-cookbook", tag: "2.2.5"
 cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ $ cd vagrant-riak-cs-cluster
 $ RIAK_CS_USE_CACHE=1 RIAK_CS_CREATE_ADMIN_USER=1 vagrant up
 ```
 
+### Environmental variables
+
+- `RIAK_CS_CREATE_ADMIN_USER` – A flag signaling whether you want an
+  administrative user for Riak CS to be created for you (default: `false`)
+- `RIAK_CS_USE_CACHE` – Whether you want to allow Vagrant to use the
+  [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) plugin or not
+  (default: `false`)
+
 ### Test cluster
 
 ``` bash


### PR DESCRIPTION
This pull request updates the default Riak version to 1.4.7:
- [x] Test Ubuntu
- [x] Test CentOS
