### PR TITLE
fix(Vagrantfile): fix Chef Omnibus version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ override_options.each { |key, value| options[key.to_sym] = value unless key.star
 
 Vagrant.configure("2") do |cluster|
   # Ensure latest version of Chef is installed.
-  cluster.omnibus.chef_version = :latest
+  cluster.omnibus.chef_version = "11.18.6"
 
   # Utilize the Cachier plugin to cache downloaded packages.
   if Vagrant.has_plugin?("vagrant-cachier") && !ENV["RIAK_CS_USE_CACHE"].nil?


### PR DESCRIPTION
This change fixes the Chef Omnibus version to be installed to 11.18.6. Later
versions of Chef handle the `file` resource differently in that it checks for
a checksum of the file, which currently fails when running a `vagrant up` from
this repository.
