### PR TITLE
fix(roles/riak.rb): remove Riak CS version constraint

### DIFF
--- a/roles/riak.rb
+++ b/roles/riak.rb
@@ -6,7 +6,6 @@ run_list(
 )
 default_attributes(
   "riak" => {
-    "cs_version" => "1.4.5",
     "args" => {
       "+zdbbl" => 96000,
       "-env" => {


### PR DESCRIPTION
This change removes the fixed Riak CS version as it is set in the `riak.rb` role
for this repository. By default, Riak `1.5.4` will be installed instead of
`1.4.5`, which causes starting the `riak` service to fail. By removing the
version constraint, Riak starts normally.
